### PR TITLE
suggested fix for issue re: using GCD for 'map' and 'each'

### DIFF
--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -172,9 +172,15 @@
 - (USArrayWrapper *(^)(UnderscoreArrayIteratorBlock))each;
 {
     return ^USArrayWrapper *(UnderscoreArrayIteratorBlock block) {
-        for (id obj in self.array) {
-            block(obj);
-        }
+        // DISPATCH_QUEUE_CONCURRENT only works on OS X >= 10.7
+        dispatch_queue_t result_queue = dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT);
+
+        dispatch_apply(self.array.count, result_queue, ^(size_t i) {
+            
+        });
+
+
+        dispatch_release(result_queue);
 
         return self;
     };
@@ -184,14 +190,13 @@
 {
     return ^USArrayWrapper *(UnderscoreArrayMapBlock block) {
         NSMutableArray *result = [NSMutableArray arrayWithCapacity:self.array.count];
+        dispatch_queue_t result_queue = dispatch_queue_create(NULL, NULL);
 
-        for (id obj in self.array) {
-            id mapped = block(obj);
+        dispatch_apply(self.array.count, result_queue, ^(size_t i) {
+            block([self.array objectAtIndex:i]);
+        });
 
-            if (mapped) {
-                [result addObject:mapped];
-            }
-        }
+        dispatch_release(result_queue);
 
         return [[USArrayWrapper alloc] initWithArray:result];
     };

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -176,9 +176,8 @@
         dispatch_queue_t result_queue = dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT);
 
         dispatch_apply(self.array.count, result_queue, ^(size_t i) {
-            
+            block([self.array objectAtIndex:i]);
         });
-
 
         dispatch_release(result_queue);
 
@@ -193,7 +192,7 @@
         dispatch_queue_t result_queue = dispatch_queue_create(NULL, NULL);
 
         dispatch_apply(self.array.count, result_queue, ^(size_t i) {
-            block([self.array objectAtIndex:i]);
+            [result addObject:block(i, [self.array objectAtIndex:i])];
         });
 
         dispatch_release(result_queue);

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -172,7 +172,7 @@
 - (USArrayWrapper *(^)(UnderscoreArrayIteratorBlock))each;
 {
     return ^USArrayWrapper *(UnderscoreArrayIteratorBlock block) {
-        // DISPATCH_QUEUE_CONCURRENT only works on OS X >= 10.7
+        // DISPATCH_QUEUE_CONCURRENT only works on OS X >= 10.7 / iOS 5
         dispatch_queue_t result_queue = dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT);
 
         dispatch_apply(self.array.count, result_queue, ^(size_t i) {
@@ -188,7 +188,7 @@
 - (USArrayWrapper *(^)(UnderscoreArrayMapBlock))map;
 {
     return ^USArrayWrapper *(UnderscoreArrayMapBlock block) {
-        NSMutableArray *result = [NSMutableArray arrayWithCapacity:self.array.count];
+        __block NSMutableArray *result = [NSMutableArray arrayWithCapacity:self.array.count];
         dispatch_queue_t result_queue = dispatch_queue_create(NULL, NULL);
 
         dispatch_apply(self.array.count, result_queue, ^(size_t i) {


### PR DESCRIPTION
Feel free to change DISPATCH_QUEUE_CONCURRENT to NULL for compatibility; I found mapping items concurrently gives segfaults all the time as the NSMutableArray has been alloc'd but not populated. AFAIK you can't apply the __block keyword to primitive arrays of NSObject pointers so a thread-safe (and lock-free) NSMutableArray replacement would have to be found to get true parallel mapping... Still, using a normal dispatch queue speeds things up a good bit.
