### PR TITLE
Add of support for 'unique' method on array wrapper

### DIFF
--- a/Underscore/USArrayWrapper.h
+++ b/Underscore/USArrayWrapper.h
@@ -65,4 +65,6 @@
 @property (readonly) BOOL (^all)(UnderscoreTestBlock block);
 @property (readonly) BOOL (^any)(UnderscoreTestBlock block);
 
+@property (readonly) USArrayWrapper *unique;
+
 @end

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -206,6 +206,21 @@
     };
 }
 
+
+- (USArrayWrapper *)unique;
+{
+    __block NSArray *(^unique)(NSArray *) = ^NSArray *(NSArray *input) {
+
+        NSSet* uniqueSet = [NSSet setWithArray:input];
+        NSArray* result = [uniqueSet allObjects];
+
+        return result;
+    };
+
+    return [USArrayWrapper wrap:unique(self.array)];
+}
+
+
 - (id (^)(UnderscoreTestBlock))find;
 {
     return ^id (UnderscoreTestBlock test) {

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -238,6 +238,21 @@ static NSArray *threeObjects;
                          @"Can extract values for the key path");
 }
 
+- (void)testUnique;
+{
+    STAssertEqualObjects(_array(emptyArray).unique.unwrap,
+    emptyArray,
+    @"Can handle empty arrays");
+
+    NSArray *samesObjects = [NSArray arrayWithObjects:[NSNumber numberWithInt:3],
+                                                 [NSNumber numberWithInt:3],
+                                                 [NSNumber numberWithInt:3],
+                                                 nil];
+
+    STAssertEquals(_array(threeObjects).unique.unwrap.count, (NSUInteger)3, @"Can extract 3 unique values");
+    STAssertEquals(_array(samesObjects).unique.unwrap.count, (NSUInteger)1, @"Can extract 1 unique value");
+}
+
 - (void)testFind;
 {
     STAssertNil(_array(emptyArray).find(^BOOL(id any){return YES;}),


### PR DESCRIPTION
Hi,

I added some support for 'unique' method on array wrapper.

Here is a sample:

``` objective-c
        NSURL *fbReposUrl = [NSURL URLWithString:@"https://api.github.com/orgs/facebook/repos"];
        NSData *data = [NSData dataWithContentsOfURL:fbReposUrl];
        NSArray *repos = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:NULL];

        NSArray *languages = _array(repos).pluck(@"language").reject([Underscore isNull]).unique.unwrap;

        NSLog(@"Unique languages used by FaceBook: %@", languages);
```
