### PR TITLE
Add support for 'uniq' method on arrays

### DIFF
--- a/Underscore/USArrayWrapper.h
+++ b/Underscore/USArrayWrapper.h
@@ -57,6 +57,8 @@
 
 @property (readonly) USArrayWrapper *(^pluck)(NSString *keyPath);
 
+@property (readonly) USArrayWrapper *uniq;
+
 @property (readonly) id (^find)(UnderscoreTestBlock block);
 
 @property (readonly) USArrayWrapper *(^filter)(UnderscoreTestBlock block);

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -213,6 +213,14 @@
     };
 }
 
+- (USArrayWrapper *)uniq;
+{
+    NSSet* uniqSet = [NSSet setWithArray:self.array];
+    NSArray* result = [uniqSet allObjects];
+
+    return [[USArrayWrapper alloc] initWithArray:result];
+}
+
 - (id (^)(UnderscoreTestBlock))find;
 {
     return ^id (UnderscoreTestBlock test) {

--- a/Underscore/Underscore+Functional.h
+++ b/Underscore/Underscore+Functional.h
@@ -53,6 +53,8 @@
 
 + (NSArray *(^)(NSArray *array, NSString *keyPath))pluck;
 
++ (NSArray *(^)(NSArray *array))uniq;
+
 + (id (^)(NSArray *array, UnderscoreTestBlock block))find;
 
 + (NSArray *(^)(NSArray *array, UnderscoreTestBlock block))filter;

--- a/Underscore/Underscore+Functional.m
+++ b/Underscore/Underscore+Functional.m
@@ -79,6 +79,13 @@
     };
 }
 
++ (NSArray *(^)(NSArray *))uniq;
+{
+    return ^(NSArray *array) {
+        return Underscore.array(array).uniq.unwrap;
+    };
+}
+
 + (NSArray *(^)(NSArray *, NSArray *))without;
 {
     return ^(NSArray *array, NSArray *values) {

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -353,6 +353,35 @@ static UnderscoreTestBlock nonePass = ^BOOL(id any) {return NO; };
                           _.array(threeObjects).pluck(@"length").unwrap);
 }
 
+
+- (void)testUniq;
+{
+    STAssertEqualObjects(_.uniq(emptyArray),
+                         emptyArray,
+                         @"Can handle empty arrays");
+
+    NSArray *samesObjects = [NSArray arrayWithObjects:[NSNumber numberWithInt:3],
+                                                      [NSNumber numberWithInt:3],
+                                                      [NSNumber numberWithInt:3],
+                                                      nil];
+
+    STAssertEquals(_.uniq(threeObjects).count,
+                            (NSUInteger)3,
+                            @"Can extract 3 unique values");
+    STAssertEquals(_.uniq(samesObjects).count,
+                            (NSUInteger)1,
+                            @"Can extract 1 unique value");
+
+    USAssertEqualObjects(_.uniq(emptyArray),
+                         _.array(emptyArray).uniq.unwrap);
+
+    USAssertEqualObjects(_.uniq(threeObjects),
+                         _.array(threeObjects).uniq.unwrap);
+    USAssertEqualObjects(_.uniq(samesObjects),
+                         _.array(samesObjects).uniq.unwrap);
+}
+
+
 - (void)testFind;
 {
     UnderscoreTestBlock endsOnZ  = ^BOOL(NSString *string) {


### PR DESCRIPTION
Hi, 

I just added support for 'uniq' with tests on development branch as stated before.

This fixes #18
