### PR TITLE
Add Sorting

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,5 @@
 Ullrich Schäfer
 Max Winde
 Alexis Kinsella
+Amiel Martin
 Robert Böhnke

--- a/Underscore/USArrayWrapper.h
+++ b/Underscore/USArrayWrapper.h
@@ -67,4 +67,6 @@
 @property (readonly) BOOL (^all)(UnderscoreTestBlock block);
 @property (readonly) BOOL (^any)(UnderscoreTestBlock block);
 
+@property (readonly) USArrayWrapper *(^sort)(UnderscoreSortBlock block);
+
 @end

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -284,4 +284,12 @@
     };
 }
 
+- (USArrayWrapper *(^)(UnderscoreSortBlock))sort
+{
+    return ^USArrayWrapper *(UnderscoreSortBlock block) {
+        NSArray *result = [self.array sortedArrayUsingComparator:block];
+        return [[USArrayWrapper alloc] initWithArray:result];
+    };
+}
+
 @end

--- a/Underscore/USConstants.h
+++ b/Underscore/USConstants.h
@@ -34,3 +34,5 @@ typedef id   (^UnderscoreArrayMapBlock)(id obj);
 
 typedef void (^UnderscoreDictionaryIteratorBlock)(id key, id obj);
 typedef id   (^UnderscoreDictionaryMapBlock)(id key, id obj);
+
+typedef NSComparisonResult (^UnderscoreSortBlock)(id a, id b);

--- a/Underscore/Underscore+Functional.h
+++ b/Underscore/Underscore+Functional.h
@@ -63,6 +63,8 @@
 + (BOOL (^)(NSArray *array, UnderscoreTestBlock block))all;
 + (BOOL (^)(NSArray *array, UnderscoreTestBlock block))any;
 
++ (NSArray *(^)(NSArray *array, UnderscoreSortBlock block))sort;
+
 #pragma mark NSDictionary style methods
 
 + (USDictionaryWrapper *(^)(NSDictionary *dictionary))dict;

--- a/Underscore/Underscore+Functional.m
+++ b/Underscore/Underscore+Functional.m
@@ -168,6 +168,13 @@
     };
 }
 
++ (NSArray *(^)(NSArray *, UnderscoreSortBlock))sort
+{
+    return ^(NSArray *array, UnderscoreSortBlock block) {
+        return Underscore.array(array).sort(block).unwrap;
+    };
+}
+
 #pragma mark NSDictionary shortcuts
 
 + (USDictionaryWrapper *(^)(NSDictionary *))dict

--- a/Underscore/Underscore.h
+++ b/Underscore/Underscore.h
@@ -46,7 +46,6 @@
 + (UnderscoreTestBlock)isString;
 
 + (UnderscoreSortBlock)sortAscending;
-+ (UnderscoreSortBlock)sortDescending;
 
 - (id)init __deprecated;
 

--- a/Underscore/Underscore.h
+++ b/Underscore/Underscore.h
@@ -45,7 +45,7 @@
 + (UnderscoreTestBlock)isNumber;
 + (UnderscoreTestBlock)isString;
 
-+ (UnderscoreSortBlock)sortAscending;
++ (UnderscoreSortBlock)compare;
 
 - (id)init __deprecated;
 

--- a/Underscore/Underscore.h
+++ b/Underscore/Underscore.h
@@ -45,6 +45,9 @@
 + (UnderscoreTestBlock)isNumber;
 + (UnderscoreTestBlock)isString;
 
++ (UnderscoreSortBlock)sortAscending;
++ (UnderscoreSortBlock)sortDescending;
+
 - (id)init __deprecated;
 
 @end

--- a/Underscore/Underscore.m
+++ b/Underscore/Underscore.m
@@ -81,6 +81,18 @@
     };
 }
 
++ (UnderscoreSortBlock)sortAscending {
+    return ^NSComparisonResult(id a, id b){
+        return [a compare:b];
+    };
+}
+
++ (UnderscoreSortBlock)sortDescending {
+    return ^NSComparisonResult(id a, id b){
+        return [b compare:a];
+    };
+}
+
 - (id)init
 {
     return [super init];

--- a/Underscore/Underscore.m
+++ b/Underscore/Underscore.m
@@ -81,7 +81,8 @@
     };
 }
 
-+ (UnderscoreSortBlock)sortAscending {
++ (UnderscoreSortBlock)compare
+{
     return ^NSComparisonResult(id a, id b){
         return [a compare:b];
     };

--- a/Underscore/Underscore.m
+++ b/Underscore/Underscore.m
@@ -87,12 +87,6 @@
     };
 }
 
-+ (UnderscoreSortBlock)sortDescending {
-    return ^NSComparisonResult(id a, id b){
-        return [b compare:a];
-    };
-}
-
 - (id)init
 {
     return [super init];

--- a/UnderscoreTests/HelperTest.m
+++ b/UnderscoreTests/HelperTest.m
@@ -68,4 +68,14 @@
     STAssertFalse(Underscore.isString([[NSObject alloc] init]), @"Returns false for NSObject");
 }
 
+- (void)testCompare
+{
+    STAssertEquals(Underscore.compare(@"a", @"b"), NSOrderedAscending,  @"Can compare correctly");
+    STAssertEquals(Underscore.compare(@"a", @"a"), NSOrderedSame,       @"Can compare correctly");
+    STAssertEquals(Underscore.compare(@"b", @"a"), NSOrderedDescending, @"Can compare correctly");
+
+    STAssertThrows(Underscore.compare(@{}, @{}),
+                   @"Comparing objects that don't respond to compare: throws an exception");
+}
+
 @end

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -530,11 +530,19 @@ static UnderscoreTestBlock nonePass = ^BOOL(id any) {return NO; };
 
 - (void)testSort
 {
-    NSArray *expectedResult = [NSArray arrayWithObjects:@"foo", @"baz", @"bar", nil];
-    USAssertEqualObjects(_.sort(threeObjects, _.sortDescending), expectedResult);
+    NSArray *notSorted = @[ @3, @1, @2 ];
+    NSArray *sorted    = @[ @1, @2, @3 ];
 
-    USAssertEqualObjects(_.sort(threeObjects, _.sortAscending),
-                         _.array(threeObjects).sort(_.sortAscending).unwrap);
+    UnderscoreSortBlock numericalSort = ^(NSNumber *a, NSNumber *b) {
+        return [a compare:b];
+    };
+
+    STAssertEqualObjects(_.sort(notSorted, numericalSort),
+                         sorted,
+                         @"Can sort elements");
+
+    USAssertEqualObjects(_.sort(notSorted, numericalSort),
+                         _.array(notSorted).sort(numericalSort).unwrap);
 }
 
 @end

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -530,15 +530,12 @@ static UnderscoreTestBlock nonePass = ^BOOL(id any) {return NO; };
 
 - (void)testSort
 {
-    UnderscoreSortBlock alphabeticalSort = ^NSComparisonResult(NSString* a, NSString* b){
-        return [a compare:b];
-    };
 
-    NSArray *expectedResult = [NSArray arrayWithObjects:@"bar", @"baz", @"foo", nil];
-    USAssertEqualObjects(_.sort(threeObjects, alphabeticalSort), expectedResult);
+    NSArray *expectedResult = [NSArray arrayWithObjects:@"foo", @"baz", @"bar", nil];
+    USAssertEqualObjects(_.sort(threeObjects, _.sortDescending), expectedResult);
 
-    USAssertEqualObjects(_.sort(threeObjects, alphabeticalSort),
-                            _.array(threeObjects).sort(alphabeticalSort).unwrap);
+    USAssertEqualObjects(_.sort(threeObjects, _.sortAscending),
+                            _.array(threeObjects).sort(_.sortAscending).unwrap);
 
 }
 

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -528,4 +528,18 @@ static UnderscoreTestBlock nonePass = ^BOOL(id any) {return NO; };
                             _.array(threeObjects).any(_.isNumber));
 }
 
+- (void)testSort
+{
+    UnderscoreSortBlock alphabeticalSort = ^NSComparisonResult(NSString* a, NSString* b){
+        return [a compare:b];
+    };
+
+    NSArray *expectedResult = [NSArray arrayWithObjects:@"bar", @"baz", @"foo", nil];
+    USAssertEqualObjects(_.sort(threeObjects, alphabeticalSort), expectedResult);
+
+    USAssertEqualObjects(_.sort(threeObjects, alphabeticalSort),
+                            _.array(threeObjects).sort(alphabeticalSort).unwrap);
+
+}
+
 @end

--- a/UnderscoreTests/USArrayTest.m
+++ b/UnderscoreTests/USArrayTest.m
@@ -530,13 +530,11 @@ static UnderscoreTestBlock nonePass = ^BOOL(id any) {return NO; };
 
 - (void)testSort
 {
-
     NSArray *expectedResult = [NSArray arrayWithObjects:@"foo", @"baz", @"bar", nil];
     USAssertEqualObjects(_.sort(threeObjects, _.sortDescending), expectedResult);
 
     USAssertEqualObjects(_.sort(threeObjects, _.sortAscending),
-                            _.array(threeObjects).sort(_.sortAscending).unwrap);
-
+                         _.array(threeObjects).sort(_.sortAscending).unwrap);
 }
 
 @end


### PR DESCRIPTION
(This replaces #24 which was based against master)

@amiel:

I mistakenly changed the test in 864008628a620cb409a0c3220ef809d301db5eee, see the comment there.

The intention of `USAssertEqualObjects` is to compare functional style methods to their equivalent chaining style. For asserting the expecting results, please use `STAssertEqualObjects` with an appropriate description.

I think `sortAscending` should be called `compare` to better communicate that it will simply call `compare:` on the passed in objects. Since Objective-C does not have generics, there is no good way to enforce that the objects actually respond to that selector. Let's be at least clear about what's going on behind the scenes.

Regarding `sortDescending`, I think a `reverse` helper block would prove to be more flexible. What do you think? I could also live with leaving it out entirely since you really just need to

``` objective-c
_.sort(array, ^(id a, id b){ [b compare:a]; }); // Return type inference FTW! 
```
