### PR TITLE
Adding tests and implementation for isBool

### DIFF
--- a/Underscore/Underscore.h
+++ b/Underscore/Underscore.h
@@ -36,6 +36,7 @@
 + (UnderscoreTestBlock(^)(id obj))isEqual;
 
 + (UnderscoreTestBlock)isArray;
++ (UnderscoreTestBlock)isBool;
 + (UnderscoreTestBlock)isDictionary;
 + (UnderscoreTestBlock)isNull;
 + (UnderscoreTestBlock)isNumber;

--- a/Underscore/Underscore.m
+++ b/Underscore/Underscore.m
@@ -57,6 +57,13 @@
     };
 }
 
++ (UnderscoreTestBlock)isBool
+{
+    return ^BOOL (id obj) {
+        return [obj isKindOfClass:[[NSNumber numberWithBool:YES] class]];
+    };
+}
+
 + (UnderscoreTestBlock)isDictionary
 {
     return ^BOOL (id obj) {

--- a/Underscore/Underscore.m
+++ b/Underscore/Underscore.m
@@ -60,7 +60,7 @@
 + (UnderscoreTestBlock)isBool
 {
     return ^BOOL (id obj) {
-        return [obj isKindOfClass:[[NSNumber numberWithBool:YES] class]];
+        return [obj isKindOfClass:[NSNumber class]] && strcmp([obj objCType], @encode(BOOL)) == 0;
     };
 }
 

--- a/UnderscoreTests/HelperTest.m
+++ b/UnderscoreTests/HelperTest.m
@@ -40,6 +40,15 @@
     STAssertFalse(Underscore.isArray([[NSObject alloc] init]), @"Returns false for NSObject");
 }
 
+- (void)testIsBool
+{
+    STAssertTrue(Underscore.isBool([NSNumber numberWithBool:YES]), @"Returns true for NSNumber with BOOL: YES");
+    STAssertTrue(Underscore.isBool([NSNumber numberWithBool:NO]),  @"Returns true for NSNumber with BOOL: NO");
+
+    STAssertFalse(Underscore.isBool([NSNumber numberWithInteger:42]), @"Returns false for NSNumber");
+    STAssertFalse(Underscore.isBool([[NSObject alloc] init]),         @"Returns false for NSObject");
+}
+
 - (void)testIsDictionary
 {
     STAssertTrue(Underscore.isDictionary([NSDictionary dictionary]), @"Returns true for NSDictionary");

--- a/UnderscoreTests/HelperTest.m
+++ b/UnderscoreTests/HelperTest.m
@@ -47,6 +47,9 @@
 
     STAssertFalse(Underscore.isBool([NSNumber numberWithInteger:42]), @"Returns false for NSNumber");
     STAssertFalse(Underscore.isBool([[NSObject alloc] init]),         @"Returns false for NSObject");
+
+    STAssertFalse(Underscore.isBool([NSNumber numberWithInt:1]), @"Returns false for NSNumber with int: 1, as its type is int, not BOOL");
+    STAssertFalse(Underscore.isBool([NSNumber numberWithInt:0]), @"Returns false for NSNumber with int: 0, as its type is int, not BOOL");
 }
 
 - (void)testIsDictionary


### PR DESCRIPTION
My iOS application interfaces with a JSON api which sometimes returns `true` or `false` values, which are placed inside an `NSNumber` wrapper when the JSON is parsed.

Objective C BOOLs are actually defined as `signed char` so calling `[num boolValue]` on an `NSNumber` with any other primitive besides `BOOL` will not yield the expected `YES` or `NO` conversions. Constantly using `isKindOfClass` checks is not an aesthetically pleasing alternative.

I've added the method `isBool` to double check if an `NSNumber` was created via `[NSNumber numberWithBool:bool]` and not some other primitive type.
